### PR TITLE
UPLC data parsing support by CBOR notation

### DIFF
--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 
 use interner::Interner;
+use pallas_primitives::{alonzo::PlutusData, Fragment};
 use peg::{error::ParseError, str::LineCol};
-use pallas_primitives::{Fragment, alonzo::PlutusData};
 
 mod interner;
 

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -7,6 +7,7 @@ use crate::{
 
 use interner::Interner;
 use peg::{error::ParseError, str::LineCol};
+use pallas_primitives::{Fragment, alonzo::PlutusData};
 
 mod interner;
 

--- a/crates/uplc/src/parser.rs
+++ b/crates/uplc/src/parser.rs
@@ -53,6 +53,7 @@ peg::parser! {
             / constant_string()
             / constant_unit()
             / constant_bool()
+            / constant_data()
             ) _* ")" {
             Term::Constant(con)
           }
@@ -109,6 +110,15 @@ peg::parser! {
 
         rule number() -> isize
           = n:$("-"* ['0'..='9']+) {? n.parse().or(Err("isize")) }
+
+        rule constant_data() -> Constant
+          = "data" _+ "#" i:ident()* {
+            Constant::Data(
+              PlutusData::decode_fragment(
+                  hex::decode(String::from_iter(i)).unwrap().as_slice()
+              ).unwrap()
+            )
+          }
 
         rule name() -> Name
           = text:ident() { Name { text, unique: 0.into() } }

--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -5,6 +5,8 @@ use crate::{
     flat::Binder,
 };
 
+use pallas_primitives::{Fragment, alonzo::PlutusData};
+
 impl<'a, T> Program<T>
 where
     T: Binder<'a>,
@@ -172,7 +174,10 @@ impl Constant {
                 .append(RcDoc::text(if *b { "True" } else { "False" })),
             Constant::ProtoList(_, _) => todo!(),
             Constant::ProtoPair(_, _, _, _) => todo!(),
-            Constant::Data(_) => todo!(),
+            Constant::Data(d) => RcDoc::text("data")
+                .append(RcDoc::line())
+                .append(RcDoc::text("#"))
+                .append(RcDoc::text(hex::encode(PlutusData::encode_fragment(d).unwrap()))),
         }
     }
 }

--- a/crates/uplc/src/pretty.rs
+++ b/crates/uplc/src/pretty.rs
@@ -5,7 +5,7 @@ use crate::{
     flat::Binder,
 };
 
-use pallas_primitives::{Fragment, alonzo::PlutusData};
+use pallas_primitives::{alonzo::PlutusData, Fragment};
 
 impl<'a, T> Program<T>
 where
@@ -177,7 +177,9 @@ impl Constant {
             Constant::Data(d) => RcDoc::text("data")
                 .append(RcDoc::line())
                 .append(RcDoc::text("#"))
-                .append(RcDoc::text(hex::encode(PlutusData::encode_fragment(d).unwrap()))),
+                .append(RcDoc::text(hex::encode(
+                    PlutusData::encode_fragment(d).unwrap(),
+                ))),
         }
     }
 }


### PR DESCRIPTION
The [UPLC documentation](https://github.com/input-output-hk/plutus/blob/master/plutus-core-spec/draft-new-specification/plutus-core-specification.pdf) and [its implementation](https://github.com/input-output-hk/plutus/blob/master/plutus-core/plutus-core/src/PlutusCore/Parser/Builtin.hs#L91) explicitely do not support the parsing of PlutusData constants in UPLC notation.

Being able to pass PlutusData into uplc is extremely handy though and a necessary feature for most useful contracts. I therefore suggest to implement a notation standard for PlutusData constants in uplc:

```
(con data #0000)
```

where `#0000` is the CBOR hex representation of a valid PlutusDatum.

This has the benefit of not requiring to introduce parsing/printing for the vast (and still unreadable) constructors etc of PlutusDatums yet granting full flexibility when using uplc notation as a compilation target (i.e. for https://github.com/ImperatorLang/imperator)