### PR TITLE
WIP: Yet another implementation of UPLC data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,6 +667,8 @@ dependencies = [
  "flat-rs",
  "hex",
  "minicbor 0.18.0",
+ "num-bigint",
+ "pallas-codec",
  "pallas-primitives",
  "peg",
  "pretty",

--- a/crates/uplc/Cargo.toml
+++ b/crates/uplc/Cargo.toml
@@ -18,9 +18,11 @@ flat-rs = { path = "../flat", version = "0.0.7" }
 hex = "0.4.3"
 minicbor = { version = "0.18.0", features = ["std"] }
 pallas-primitives = "0.12.0"
+pallas-codec = "0.12.0"
 peg = "0.8.0"
 pretty = "0.11.3"
 thiserror = "1.0.31"
+num-bigint = "0.4.3"
 
 [dev-dependencies]
 hex = "0.4.3"


### PR DESCRIPTION
Because of the limitation noted in #37 (namely, the inherent unreadability of CBOR constants in source code) I am presenting yet another option for implementing plutus data parsing.

This approach parses (a subset of) possible PlutusData notations.
Its notation is oriented towards the notation used in [pluto](https://github.com/Plutonomicon/pluto) (which however, only offers an even smaller range of options).

The supported types should be enough for any reasonable approach at writing plutus code from hand.
Because of the inability to differentiate between subtly different plutus data types (i.e. BigUInt vs Int, ArrayIndef vs ArrayDef), this notation is _not_ suitable for pretty printing arbitrary flattened data.

Option A) I would rather suggest to implement this in conjunction with #37 and the change the notation for CBOR encoded plutus data to `con data CBOR#0000`. This maintains the freedom to being able to precisely define the plutus data type that is intended while also enabling human readable source code.

Option B) An alternative is to extend the notation used herein to be able to differentiate between named subtly different datatypes (i.e. using `i[ ..]` and  `[ ...]` for differentiating between indefinite and definite length arrays). This would then also enable pretty prenting and make the CBOR notation option not necessary.

I would like to have some feedback from the maintainers on which direction this should go from their perspective - i.e. whether they would like to specify a notation for parsing plutus data in uplc source code without any official spec as basis, but therefore fully specifying a human readable uplc notation, or (temporarily) supporting specification of plutus data as CBOR hex.
