### PR TITLE
Proptest added, found bug on encoding bytes input larger than 255 bytes.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,7 @@ version = "0.0.7"
 dependencies = [
  "anyhow",
  "quickcheck",
+ "quickcheck_macros",
  "thiserror",
 ]
 
@@ -482,6 +483,17 @@ dependencies = [
  "env_logger",
  "log",
  "rand",
+]
+
+[[package]]
+name = "quickcheck_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b22a693222d716a9587786f37ac3f6b4faedb5b80c23914e7303ff5a1d8016e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "aiken"
 version = "0.0.9"
 dependencies = [
@@ -131,6 +140,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "129eabb7b0b78644a3a7e7cf220714aba47463bb281f69fa7a71ca5d12564cca"
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,6 +163,7 @@ name = "flat-rs"
 version = "0.0.7"
 dependencies = [
  "anyhow",
+ "quickcheck",
  "thiserror",
 ]
 
@@ -242,6 +262,12 @@ checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "minicbor"
@@ -448,6 +474,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quickcheck"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
+dependencies = [
+ "env_logger",
+ "log",
+ "rand",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,6 +539,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "regex"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
 ]
 
 [[package]]

--- a/crates/flat/Cargo.toml
+++ b/crates/flat/Cargo.toml
@@ -13,3 +13,6 @@ authors = ["Lucas Rosa <x@rvcas.dev>", "Kasey White <kwhitemsg@gmail.com>"]
 [dependencies]
 anyhow = "1.0.57"
 thiserror = "1.0.31"
+
+[dev-dependencies]
+quickcheck = "1"

--- a/crates/flat/Cargo.toml
+++ b/crates/flat/Cargo.toml
@@ -16,3 +16,4 @@ thiserror = "1.0.31"
 
 [dev-dependencies]
 quickcheck = "1"
+quickcheck_macros = "1"

--- a/crates/flat/src/encode/encoder.rs
+++ b/crates/flat/src/encode/encoder.rs
@@ -80,7 +80,7 @@ impl Encoder {
             return Err(Error::BufferNotByteAligned);
         }
 
-        self.write_blk(arr, &mut 0);
+        self.write_blk(arr);
 
         Ok(self)
     }
@@ -277,20 +277,13 @@ impl Encoder {
     /// Following that it writes the next 255 bytes from the array.
     /// After reaching the end of the buffer we write a 0 byte. Only write 0 if the byte array is empty.
     /// This is byte alignment agnostic.
-    fn write_blk(&mut self, arr: &[u8], src_ptr: &mut usize) {
-        loop {
-            let src_len = arr.len() - *src_ptr;
-            let blk_len = src_len.min(255);
+    fn write_blk(&mut self, arr: &[u8]) {
+        let chunks = arr.chunks(255);
 
-            self.buffer.push(blk_len as u8);
-
-            if blk_len == 0 {
-                return;
-            }
-
-            self.buffer.extend(&arr[*src_ptr..blk_len]);
-
-            *src_ptr += blk_len;
+        for chunk in chunks {
+            self.buffer.push(chunk.len() as u8);
+            self.buffer.extend(chunk);
         }
+        self.buffer.push(0);
     }
 }

--- a/crates/flat/src/encode/encoder.rs
+++ b/crates/flat/src/encode/encoder.rs
@@ -278,19 +278,19 @@ impl Encoder {
     /// After reaching the end of the buffer we write a 0 byte. Only write 0 if the byte array is empty.
     /// This is byte alignment agnostic.
     fn write_blk(&mut self, arr: &[u8], src_ptr: &mut usize) {
-        let src_len = arr.len() - *src_ptr;
-        let blk_len = src_len.min(255);
+        loop {
+            let src_len = arr.len() - *src_ptr;
+            let blk_len = src_len.min(255);
 
-        self.buffer.push(blk_len as u8);
+            self.buffer.push(blk_len as u8);
 
-        if blk_len == 0 {
-            return;
+            if blk_len == 0 {
+                return;
+            }
+
+            self.buffer.extend(&arr[*src_ptr..blk_len]);
+
+            *src_ptr += blk_len;
         }
-
-        self.buffer.extend(&arr[*src_ptr..blk_len]);
-
-        *src_ptr += blk_len;
-
-        self.write_blk(arr, src_ptr);
     }
 }

--- a/crates/flat/src/lib.rs
+++ b/crates/flat/src/lib.rs
@@ -45,24 +45,3 @@ where
 
     Ok(value)
 }
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn encode_bool() {
-        let bytes = super::encode(&true).unwrap();
-
-        assert_eq!(bytes, vec![0b10000001]);
-
-        let bytes = super::encode(&false).unwrap();
-
-        assert_eq!(bytes, vec![0b00000001]);
-    }
-
-    #[test]
-    fn encode_u8() {
-        let bytes = super::encode(&3_u8).unwrap();
-
-        assert_eq!(bytes, vec![0b00000011, 0b00000001]);
-    }
-}

--- a/crates/flat/src/zigzag.rs
+++ b/crates/flat/src/zigzag.rs
@@ -1,7 +1,7 @@
 pub fn to_usize(x: isize) -> usize {
     let double_x = x << 1;
 
-    if x >= 0 {
+    if x.is_positive() || x == 0 {
         double_x as usize
     } else {
         (-double_x - 1) as usize
@@ -9,19 +9,5 @@ pub fn to_usize(x: isize) -> usize {
 }
 
 pub fn to_isize(u: usize) -> isize {
-    let s = u as isize;
-
-    (s >> 1) ^ -(s & 1)
-}
-
-#[cfg(test)]
-mod test {
-    #[test]
-    fn convert() {
-        let n = -12;
-        let unsigned = super::to_usize(n);
-        let signed = super::to_isize(unsigned);
-
-        assert_eq!(n, signed)
-    }
+    ((u >> 1) as isize) ^ (-((u & 1) as isize))
 }

--- a/crates/flat/tests/flat_test.rs
+++ b/crates/flat/tests/flat_test.rs
@@ -1,7 +1,19 @@
+#[cfg(test)]
+extern crate quickcheck;
+
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
 use flat_rs::{decode, encode};
+use quickcheck::{Arbitrary, Gen};
 
 #[cfg(test)]
 mod test {
+    use core::num;
+
+    use quickcheck::Arbitrary;
+
     #[test]
     fn encode_bool() {
         let bytes = crate::encode(&true).unwrap();
@@ -30,5 +42,36 @@ mod test {
         let decoded: u8 = crate::decode(bytes.as_slice()).unwrap();
 
         assert_eq!(decoded, 3_u8);
+    }
+
+    #[quickcheck]
+    fn encode_vec_u8(xs: Vec<u8>) -> bool {
+        let bytes = crate::encode(&xs).unwrap();
+        let decoded: Vec<u8> = crate::decode(&bytes).unwrap();
+        decoded == xs
+    }
+
+    #[derive(Clone, Debug)]
+    struct BigChunk(Vec<u8>);
+
+    impl Arbitrary for BigChunk {
+        fn arbitrary(g: &mut quickcheck::Gen) -> Self {
+            let num_of_element = g.choose(&[255, 256, 244, 100]).unwrap();
+
+            let mut vec = Vec::with_capacity(*num_of_element);
+            for _ in 1..*num_of_element {
+                vec.push(u8::arbitrary(g));
+            }
+
+            BigChunk(vec)
+        }
+    }
+
+    #[quickcheck]
+    fn encode_write_blk(xs: BigChunk) -> bool {
+        let xs = xs.0;
+        let bytes = crate::encode(&xs).unwrap();
+        let decoded: Vec<u8> = crate::decode(&bytes).unwrap();
+        decoded == xs
     }
 }

--- a/crates/flat/tests/flat_test.rs
+++ b/crates/flat/tests/flat_test.rs
@@ -1,0 +1,34 @@
+use flat_rs::{decode, encode};
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn encode_bool() {
+        let bytes = crate::encode(&true).unwrap();
+
+        assert_eq!(bytes, vec![0b10000001]);
+
+        let decoded: bool = crate::decode(bytes.as_slice()).unwrap();
+
+        assert_eq!(decoded, true);
+
+        let bytes = crate::encode(&false).unwrap();
+
+        assert_eq!(bytes, vec![0b00000001]);
+
+        let decoded: bool = crate::decode(bytes.as_slice()).unwrap();
+
+        assert_eq!(decoded, false);
+    }
+
+    #[test]
+    fn encode_u8() {
+        let bytes = crate::encode(&3_u8).unwrap();
+
+        assert_eq!(bytes, vec![0b00000011, 0b00000001]);
+
+        let decoded: u8 = crate::decode(bytes.as_slice()).unwrap();
+
+        assert_eq!(decoded, 3_u8);
+    }
+}

--- a/crates/flat/tests/flat_test.rs
+++ b/crates/flat/tests/flat_test.rs
@@ -5,46 +5,74 @@ extern crate quickcheck;
 #[macro_use(quickcheck)]
 extern crate quickcheck_macros;
 
-use flat_rs::{decode, encode};
-
 #[cfg(test)]
 mod test {
+    use flat_rs::filler::Filler;
+    use flat_rs::{decode, encode};
     use quickcheck::Arbitrary;
 
     #[test]
     fn encode_bool() {
-        let bytes = crate::encode(&true).unwrap();
+        let bytes = encode(&true).unwrap();
 
         assert_eq!(bytes, vec![0b10000001]);
 
-        let decoded: bool = crate::decode(bytes.as_slice()).unwrap();
+        let decoded: bool = decode(bytes.as_slice()).unwrap();
 
         assert_eq!(decoded, true);
 
-        let bytes = crate::encode(&false).unwrap();
+        let bytes = encode(&false).unwrap();
 
         assert_eq!(bytes, vec![0b00000001]);
 
-        let decoded: bool = crate::decode(bytes.as_slice()).unwrap();
+        let decoded: bool = decode(bytes.as_slice()).unwrap();
 
         assert_eq!(decoded, false);
     }
 
     #[test]
     fn encode_u8() {
-        let bytes = crate::encode(&3_u8).unwrap();
+        let bytes = encode(&3_u8).unwrap();
 
         assert_eq!(bytes, vec![0b00000011, 0b00000001]);
 
-        let decoded: u8 = crate::decode(bytes.as_slice()).unwrap();
+        let decoded: u8 = decode(bytes.as_slice()).unwrap();
 
         assert_eq!(decoded, 3_u8);
     }
 
     #[quickcheck]
+    fn encode_isize(x: isize) -> bool {
+        let bytes = encode(&x).unwrap();
+        let decoded: isize = decode(&bytes).unwrap();
+        decoded == x
+    }
+
+    #[quickcheck]
+    fn encode_usize(x: usize) -> bool {
+        let bytes = encode(&x).unwrap();
+        let decoded: usize = decode(&bytes).unwrap();
+        decoded == x
+    }
+
+    #[quickcheck]
+    fn encode_char(c: char) -> bool {
+        let bytes = encode(&c).unwrap();
+        let decoded: char = decode(&bytes).unwrap();
+        decoded == c
+    }
+
+    #[quickcheck]
+    fn encode_string(str: String) -> bool {
+        let bytes = encode(&str).unwrap();
+        let decoded: String = decode(&bytes).unwrap();
+        decoded == str
+    }
+
+    #[quickcheck]
     fn encode_vec_u8(xs: Vec<u8>) -> bool {
-        let bytes = crate::encode(&xs).unwrap();
-        let decoded: Vec<u8> = crate::decode(&bytes).unwrap();
+        let bytes = encode(&xs).unwrap();
+        let decoded: Vec<u8> = decode(&bytes).unwrap();
         decoded == xs
     }
 
@@ -53,22 +81,60 @@ mod test {
 
     impl Arbitrary for BigChunk {
         fn arbitrary(g: &mut quickcheck::Gen) -> Self {
-            let num_of_element = g.choose(&[255, 256, 244, 100]).unwrap();
+            let num_of_element = g.choose(&[257]).unwrap();
 
-            let mut vec = Vec::with_capacity(*num_of_element);
-            for _ in 1..*num_of_element {
-                vec.push(u8::arbitrary(g));
-            }
+            let vec = (0..*num_of_element).map(|_| u8::arbitrary(g)).collect();
 
             BigChunk(vec)
         }
     }
 
     #[quickcheck]
-    fn encode_write_blk(xs: BigChunk) -> bool {
+    fn encode_big_vec_u8(xs: BigChunk) -> bool {
         let xs = xs.0;
-        let bytes = crate::encode(&xs).unwrap();
-        let decoded: Vec<u8> = crate::decode(&bytes).unwrap();
+        let bytes = encode(&xs).unwrap();
+        let decoded: Vec<u8> = decode(&bytes).unwrap();
         decoded == xs
+    }
+
+    #[quickcheck]
+    fn encode_arr_u8(xs: Vec<u8>) -> bool {
+        let bytes = encode(&xs.as_slice()).unwrap();
+        let decoded: Vec<u8> = decode(&bytes).unwrap();
+        decoded == xs
+    }
+
+    #[quickcheck]
+    fn encode_big_arr_u8(xs: BigChunk) -> bool {
+        let xs = xs.0;
+        let bytes = encode(&xs.as_slice()).unwrap();
+        let decoded: Vec<u8> = decode(&bytes).unwrap();
+        decoded == xs
+    }
+
+    #[quickcheck]
+    fn encode_boxed(c: char) -> bool {
+        let boxed = Box::new(c);
+        let bytes = encode(&boxed).unwrap();
+        let decoded: char = decode(&bytes).unwrap();
+        decoded == c
+    }
+
+    #[test]
+    fn encode_filler() {
+        let bytes = encode(&Filler::FillerEnd).unwrap();
+
+        assert_eq!(bytes, vec![0b0000001, 0b00000001]);
+
+        let bytes = encode(&Filler::FillerStart(Box::new(Filler::FillerEnd))).unwrap();
+
+        assert_eq!(bytes, vec![0b0000001, 0b00000001]);
+
+        let bytes = encode(&Filler::FillerStart(Box::new(Filler::FillerStart(
+            Box::new(Filler::FillerEnd),
+        ))))
+        .unwrap();
+
+        assert_eq!(bytes, vec![0b0000001, 0b00000001]);
     }
 }

--- a/crates/flat/tests/flat_test.rs
+++ b/crates/flat/tests/flat_test.rs
@@ -6,12 +6,9 @@ extern crate quickcheck;
 extern crate quickcheck_macros;
 
 use flat_rs::{decode, encode};
-use quickcheck::{Arbitrary, Gen};
 
 #[cfg(test)]
 mod test {
-    use core::num;
-
     use quickcheck::Arbitrary;
 
     #[test]

--- a/crates/flat/tests/zigzag_test.rs
+++ b/crates/flat/tests/zigzag_test.rs
@@ -1,0 +1,18 @@
+#[cfg(test)]
+extern crate quickcheck;
+
+#[cfg(test)]
+#[macro_use(quickcheck)]
+extern crate quickcheck_macros;
+
+#[cfg(test)]
+mod test {
+    use flat_rs::zigzag::{to_isize, to_usize};
+
+    #[quickcheck]
+    fn zigzag(i: isize) -> bool {
+        let u = to_usize(i);
+        let converted_i = to_isize(u);
+        converted_i == i
+    }
+}

--- a/crates/flat/tests/zigzag_test.rs
+++ b/crates/flat/tests/zigzag_test.rs
@@ -15,4 +15,11 @@ mod test {
         let converted_i = to_isize(u);
         converted_i == i
     }
+
+    #[quickcheck]
+    fn zagzig(u: usize) -> bool {
+        let i = to_isize(u);
+        let converted_u = to_usize(i);
+        converted_u == u
+    }
 }


### PR DESCRIPTION
First issue on this repo.

I was improving the `write_blk` function which previously implemented using recursive function and pointer arithmetic. Turns out there is no test case for large input for Encode trait. Therefore I add some test cases to test it.

And also fixed some weird bug on the zig zag encoding.

So it should be working for now.

PS: is it okay to introduce dependency [bumpalo](https://github.com/fitzgen/bumpalo)? I see there are a lot of vector push so I suspect apply this and there will be performance improvement. (of course, benchmark is needed)