### PR TITLE
Print machine logs (debug trace)

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -97,7 +97,7 @@ fn main() -> anyhow::Result<()> {
                     Program::<NamedDeBruijn>::try_from(prog)?
                 };
 
-                let (term, cost, _logs) = program.eval();
+                let (term, cost, logs) = program.eval();
 
                 match term {
                     Ok(term) => {
@@ -121,6 +121,10 @@ fn main() -> anyhow::Result<()> {
                     "\nBudget\n------\ncpu: {}\nmemory: {}\n",
                     cost.cpu, cost.mem
                 );
+                println!(
+                    "\nLogs\n----\n{}",
+                    logs.join("\n")
+                )
             }
         },
     }


### PR DESCRIPTION
During the evaluation of a smart contract script, the user may invoke trace to generate a debug log as a side-effect.

This may be made optional with a --verbose flag, but usually the user wants to see all invocations of the Trace command.

Just not showing the content is very confusing, as the user would expect any kind of output when Trace is invoked (I for example need this when evaluating the execution path of transpiled Imperator/PySCC programs)