### PR TITLE
Added deserialisation error to machine

### DIFF
--- a/crates/uplc/src/machine/error.rs
+++ b/crates/uplc/src/machine/error.rs
@@ -44,4 +44,6 @@ pub enum Error {
     UnexpectedEd25519PublicKeyLength(usize),
     #[error("Ed25519S Signature should be 64 bytes but it was {0}")]
     UnexpectedEd25519SignatureLength(usize),
+    #[error("Failed to deserialise PlutusData:\n\n{0:#?}")]
+    DeserialisationError(Value),
 }

--- a/crates/uplc/src/machine/runtime.rs
+++ b/crates/uplc/src/machine/runtime.rs
@@ -760,7 +760,7 @@ impl DefaultFunction {
                         )),
                     )))
                 }
-                _ => unreachable!(),
+                v => Err(Error::DeserialisationError(v.clone())),
             },
             DefaultFunction::UnMapData => match &args[0] {
                 Value::Con(Constant::Data(PlutusData::Map(m))) => {
@@ -779,7 +779,7 @@ impl DefaultFunction {
                             .collect(),
                     )))
                 }
-                _ => unreachable!(),
+                v => Err(Error::DeserialisationError(v.clone())),
             },
             DefaultFunction::UnListData => match &args[0] {
                 Value::Con(Constant::Data(PlutusData::Array(l))) => {
@@ -791,7 +791,7 @@ impl DefaultFunction {
                             .collect(),
                     )))
                 }
-                _ => unreachable!(),
+                v => Err(Error::DeserialisationError(v.clone())),
             },
             DefaultFunction::UnIData => match &args[0] {
                 Value::Con(Constant::Data(PlutusData::BigInt(b))) => {
@@ -803,13 +803,13 @@ impl DefaultFunction {
                         unreachable!()
                     }
                 }
-                _ => unreachable!(),
+                v => Err(Error::DeserialisationError(v.clone())),
             },
             DefaultFunction::UnBData => match &args[0] {
                 Value::Con(Constant::Data(PlutusData::BoundedBytes(b))) => {
                     Ok(Value::Con(Constant::ByteString(b.to_vec())))
                 }
-                _ => unreachable!(),
+                v => Err(Error::DeserialisationError(v.clone())),
             },
             DefaultFunction::EqualsData => match (&args[0], &args[1]) {
                 (Value::Con(Constant::Data(d1)), Value::Con(Constant::Data(d2))) => {


### PR DESCRIPTION
Applying an accidental wrong datum/redeemer to the tx lets the machine panic. From the WASM side it's really hard to understand what happened. This error handling helps with what's going on.