### PR TITLE
fix the cbor_hex flag for `aiken uplc flat`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 ### Added
 
 - **aiken**: `Project` module which is responsible loading modules and running the compilation steps
+- **aiken**: `UplcCommand::Flat` flip the cbor_hex if condition so that the correct logic runs when using the flag

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -173,7 +173,7 @@ fn main() -> miette::Result<()> {
 
                 let program = Program::<DeBruijn>::try_from(program).into_diagnostic()?;
 
-                if cbor_hex {
+                if !cbor_hex {
                     let bytes = program.to_flat().into_diagnostic()?;
 
                     if print {


### PR DESCRIPTION
closes #69 