### PR TITLE
More record sugar in patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - **aiken-lang**: code generation for pattern matching expressions
 - **aiken-lang**: extended script context
 - **aiken-lang**: added Option to builtins
+- **aiken-lang**: properly handle record parsing and sugar in patterns
 
 ## [v0.0.25] - 2022-11-14
 

--- a/crates/lang/src/format.rs
+++ b/crates/lang/src/format.rs
@@ -1270,6 +1270,12 @@ impl<'comments> Formatter<'comments> {
     }
 
     fn pattern_call_arg<'a>(&mut self, arg: &'a CallArg<UntypedPattern>) -> Document<'a> {
+        if let (UntypedPattern::Var { name, .. }, Some(label)) = (&arg.value, &arg.label) {
+            if name == label {
+                return self.pattern(&arg.value);
+            }
+        }
+
         arg.label
             .as_ref()
             .map(|s| s.to_doc().append(": "))

--- a/examples/sample/validators/swap.ak
+++ b/examples/sample/validators/swap.ak
@@ -35,8 +35,8 @@ pub fn spend(
 ) -> Bool {
   let x = datum.rdmr
   when x is {
-    sample.Buy { fin: fin, .. } -> fin > 0
-    sample.Sell { find: fin, .. } -> fin > 0
+    sample.Buy { fin, .. } -> fin > 0
+    sample.Sell { find, .. } -> find > 0
     sample.Hold(some) -> some > 0
   }
 }


### PR DESCRIPTION
the parser can now fill in a label for unlabeled fields in a record. Before no label meant it was treated as a positional, so there were strange cases that didn't infer the right types for the right fields because the typechecker assumed it was a positional CallArg.