### PR TITLE
Update `aiken fmt` help text to "Format an Aiken project" from "Create a new Aiken project"

### DIFF
--- a/crates/cli/src/cmd/fmt.rs
+++ b/crates/cli/src/cmd/fmt.rs
@@ -1,5 +1,5 @@
 #[derive(clap::Args)]
-/// Create a new Aiken project
+/// Format an Aiken project
 pub struct Args {
     /// Files to format
     #[clap(default_value = ".")]


### PR DESCRIPTION
When you enter `aiken --help` the `fmt` text is `Create a new Aiken project` which is the same text as the text from the `new` subcommand.

This PR updates the help text to say `Format an Aiken project`.