### PR TITLE
Refactor compile options

### DIFF
--- a/crates/project/src/options.rs
+++ b/crates/project/src/options.rs
@@ -1,0 +1,9 @@
+pub struct Options {
+    pub code_gen_mode: CodeGenMode,
+}
+
+pub enum CodeGenMode {
+    Test,
+    Build(bool),
+    NoOp,
+}


### PR DESCRIPTION
I've created a new struct and enum for handling the different modes the code gen can be used under. This is a bit cleaner than the spider web of bools we were starting to accumulate.